### PR TITLE
Adjust the width of images on small screens.

### DIFF
--- a/assets/scss/base/_reset.scss
+++ b/assets/scss/base/_reset.scss
@@ -24,6 +24,7 @@
 		font-size: 100%;
 		font: inherit;
 		vertical-align: baseline;
+                width: 100%;
 	}
 
 	article, aside, details, figcaption, figure,

--- a/exampleSite/content/post/post_with_pictures.en.md
+++ b/exampleSite/content/post/post_with_pictures.en.md
@@ -1,0 +1,19 @@
++++
+title = 'image post'
+slug = 'image-post'
+image = 'images/pic01.jpg'
+date = "2020-05-10T00:00:00"
+description = 'a post with an image'
+disableComments = true
++++
+
+This post has two images:
+
+1. The title image.
+2. An image in the body.
+
+Here it comes:
+
+![the alt text of the picture](/images/pic02.jpg)
+
+There it was.

--- a/exampleSite/resources/_gen/assets/scss/scss/main.scss_12bfed357d24ca59ff7ceeb30292a324.content
+++ b/exampleSite/resources/_gen/assets/scss/scss/main.scss_12bfed357d24ca59ff7ceeb30292a324.content
@@ -21,7 +21,8 @@ section, summary, time, mark, audio, video {
   border: 0;
   font-size: 100%;
   font: inherit;
-  vertical-align: baseline; }
+  vertical-align: baseline;
+  width: 100%; }
 
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {


### PR DESCRIPTION
This should solve Issue #82

I also added a post with an image in the body  to the example site. This is how it looks now on thin screens (compare with the screenshot from the issue):

![test_post_with_image](https://user-images.githubusercontent.com/3586246/81502740-0d330b00-92e0-11ea-913b-aaabacab55cb.png)

Note that I don't know what I am doing with sscs and css. I solved this by fooling around. I think the code is right and the testpost looks good, but someone who knows his/her way around web technologies should doublecheck this.
