### PR TITLE
Deprecation warning

### DIFF
--- a/assets/scss/libs/_breakpoints.scss
+++ b/assets/scss/libs/_breakpoints.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: null;
 
 // Mixins.
 


### PR DESCRIPTION
DEPRECATION WARNING on line 7 of /Users/roger/Documents/Development/Hugo/bsp/themes/massively/assets/scss/libs/_breakpoints.scss:
!global assignments won't be able to declare new variables in future versions.
Consider adding `$breakpoints: null` at the top level.