### PR TITLE
👷 Add hugo max version e2e to CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  min_hugo_build:
     name: hugo min version
     runs-on: ubuntu-latest
 
@@ -29,7 +29,7 @@ jobs:
     - run: npm ci
     - run: npm run e2e:headless
 
-  build:
+  max_hugo_build:
     name: hugo max version
     runs-on: ubuntu-latest
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: hugo min version
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,6 +20,28 @@ jobs:
       uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: "0.54.0"
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run e2e:headless
+
+  build:
+    name: hugo max version
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - name: Setup Hugo
+      uses: peaceiris/actions-hugo@v2
+      with:
+        hugo-version: "0.94.2"
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2


### PR DESCRIPTION
Currently, the CI only runs automation tests against the minimum supported Hugo version.

PR updates the CI to also run the automation tests against the maximum supported version.