### PR TITLE
⬆️ Upgrade Hugo: v0.102.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: "0.101.0"
+        hugo-version: "0.102.3"
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
 [module]
   [module.hugoVersion]
     min = "0.54.0"
-    max = "0.101.0"
+    max = "0.102.3"


### PR DESCRIPTION
Upgrades the max compatible version of Hugo to [v0.102.3](https://github.com/gohugoio/hugo/releases/tag/v0.102.3)