### PR TITLE
Upgrade Hugo: v1.111.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: "0.110.0"
+        hugo-version: "0.111.3"
         extended: true
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
 [module]
   [module.hugoVersion]
     min = "0.54.0"
-    max = "0.110.0"
+    max = "0.111.3"


### PR DESCRIPTION
Upgrades the max compatible version of Hugo to [v0.111.3](https://github.com/gohugoio/hugo/releases/tag/v0.111.3)