### PR TITLE
feat: Add German translation file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The cover image URL is hard-coded, therefore to replace this add an image to the
  - [Japanese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/ja.toml)
  - [Simplified Chinese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/zh.toml)
  - [Spanish](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/es.toml)
+ - [Deutsch](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/de.toml)
 
 ## Custom Front Matter
  - `disableComments` - If set to `true` this will disable comments on the post when Disqus is enabled.

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -1,0 +1,34 @@
+[CONTACT_ADDRESS]
+  other = "Addresse"
+[CONTACT_EMAIL]
+  other = "Email"
+[CONTACT_FORM_FIELD_EMAIL]
+  other = "Email"
+[CONTACT_FORM_FIELD_MESSAGE]
+  other = "Nachricht"
+[CONTACT_FORM_FIELD_NAME]
+  other = "Name"
+[CONTACT_FORM_SUBMIT_SEND_MESSAGE]
+  other = "Nachricht senden"
+[CONTACT_PHONE]
+  other = "Telefon"
+[CONTACT_SOCIAL]
+  other = "Social Media"
+[COPYRIGHT_MESSAGE_1]
+  other = "Design: [HTML5 UP](https://html5up.net)"
+[COPYRIGHT_MESSAGE_2]
+  other = "Hugo Port: [curtiscode](https://curtiscode.dev)"
+[INTRO_CONTINUE]
+  other = "Weiter"
+[NAV_MENU]
+  other = "Menü"
+[NAV_CONTACT]
+  other = "Kontakt"
+[PAGINATION_NEXT]
+  other = "Weiter"
+[PAGINATION_PREVIOUS]
+  other = "Zurück"
+[PAGINATION_FIRST]
+  other = "Erste"
+[PAGINATION_LAST]
+  other = "Letzte"


### PR DESCRIPTION
See https://github.com/curtiscde/hugo-theme-massively/issues/131, adds german language support.

In case you want to have the example pages translated as well, feel free to reach out.