### PR TITLE
Upgrade Hugo: v0.136.5

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: "0.54.0"
+        hugo-version: "0.120.0"
         extended: true
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: "0.129.0"
+        hugo-version: "0.136.5"
         extended: true
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hugo Theme Massively
 
-![](https://img.shields.io/badge/Hugo-%5E0.54.0-ff4088?style=flat-square&logo=hugo) [![e2e tests](https://github.com/curtiscde/hugo-theme-massively/actions/workflows/e2e.yml/badge.svg)](https://github.com/curtiscde/hugo-theme-massively/actions/workflows/e2e.yml)
+![](https://img.shields.io/badge/Hugo-%5E0.120.0-ff4088?style=flat-square&logo=hugo) [![e2e tests](https://github.com/curtiscde/hugo-theme-massively/actions/workflows/e2e.yml/badge.svg)](https://github.com/curtiscde/hugo-theme-massively/actions/workflows/e2e.yml)
 
 Massively theme ported from [HTML5 UP](https://html5up.net/) for use with the [Hugo static site generator](https://gohugo.io/).
 
@@ -8,7 +8,7 @@ Massively theme ported from [HTML5 UP](https://html5up.net/) for use with the [H
 
 ## Demo
 
-https://hugo-theme-massively.netlify.com/
+<https://hugo-theme-massively.netlify.com/>
 
 ## Setup
 
@@ -16,15 +16,17 @@ https://hugo-theme-massively.netlify.com/
 
 See the demo's configuration as an example:
 
-https://github.com/curtiscde/hugo-theme-massively/blob/master/exampleSite/config-prod.toml
+<https://github.com/curtiscde/hugo-theme-massively/blob/master/exampleSite/config-prod.toml>
 
 #### Hugo Internal Templates
+
 The theme currently also supports the following ["internal templates" supplied by Hugo](https://gohugo.io/templates/internal/)
 
- - [Disqus](https://gohugo.io/templates/internal/#disqus)
- - [Google Analytics](https://gohugo.io/templates/internal/#configure-google-analytics)
+- [Disqus](https://gohugo.io/templates/internal/#disqus)
+- [Google Analytics](https://gohugo.io/templates/internal/#configure-google-analytics)
 
 ### Cover Image
+
 The cover image URL is hard-coded, therefore to replace this add an image to the following location in your Hugo application:
 
 ```
@@ -32,15 +34,17 @@ The cover image URL is hard-coded, therefore to replace this add an image to the
 ```
 
 ### Supported Languages
- - [English](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/en.toml)
- - [Dutch](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/nl.toml)
- - [French](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/fr.toml)
- - [Japanese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/ja.toml)
- - [Simplified Chinese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/zh.toml)
- - [Spanish](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/es.toml)
+
+- [English](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/en.toml)
+- [Dutch](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/nl.toml)
+- [French](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/fr.toml)
+- [Japanese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/ja.toml)
+- [Simplified Chinese](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/zh.toml)
+- [Spanish](https://github.com/curtiscde/hugo-theme-massively/blob/master/i18n/es.toml)
 
 ## Custom Front Matter
- - `disableComments` - If set to `true` this will disable comments on the post when Disqus is enabled.
+
+- `disableComments` - If set to `true` this will disable comments on the post when Disqus is enabled.
 
 ## Custom `<head>`
 
@@ -53,28 +57,30 @@ If you wish to add custom CSS overrides, or other elements in the `<head>`, then
 #### Production Deployment
 
 ```
-$ cd exampleSite
-$ hugo --config config-prod.toml
+cd exampleSite
+hugo --config config-prod.toml
 ```
 
 #### Running Locally
 
 ```shell
-$ npm i
-$ npm run hugo-dev
+npm i
+npm run hugo-dev
 ```
+
 OR
+
 ```shell
-$ cd exampleSite
-$ hugo server --themesDir ../..
+cd exampleSite
+hugo server --themesDir ../..
 ```
 
 ## Original Theme Credits
 
- - [Massively by HTML5 UP](https://html5up.net/massively)
+- [Massively by HTML5 UP](https://html5up.net/massively)
 
- ## License
+## License
 
-This hugo theme is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/). 
+This hugo theme is licensed under the [Creative Commons Attribution 3.0 License](https://creativecommons.org/licenses/by/3.0/).
 
 Read More - [LICENSE](LICENSE)

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
 [module]
   [module.hugoVersion]
     min = "0.54.0"
-    max = "0.129.0"
+    max = "0.136.5"

--- a/layouts/partials/htmlhead.html
+++ b/layouts/partials/htmlhead.html
@@ -10,7 +10,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<!-- CSS -->
-		{{ if .Site.IsServer }}
+		{{ if hugo.IsServer }}
 		{{ $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "main.scss" . | toCSS (dict "targetPath" "assets/css/main.css" "enableSourceMap" true) }}
 		<link rel="stylesheet" href="{{ ($style).RelPermalink }}">
 		{{ else }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@
   command = "hugo --gc --themesDir ../.. --config config-prod.toml"
 
 [build.environment]
-  HUGO_VERSION = "0.54.0"
+  HUGO_VERSION = "0.120.0"
   HUGO_THEME = "repo"


### PR DESCRIPTION
 - Upgrades to Hugo `v0.136.5`
 - Swaps deprecated `.Site.IsServer` usage to preferred `hugo.IsServer`
 - Upgrades min version of Hugo requires to `v0.120.0`